### PR TITLE
Add nix to README, move nix below native package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ cpm [i|r|l|u|U|s|S|c|h] [pkg]...
 - apt (Debian/Ubuntu)
 - dnf (Fedora)
 - MacPorts (MacOS)
+- nix (Global/NixOS)
 - pacman (Arch)
 - xbps (Void)
 

--- a/cpm
+++ b/cpm
@@ -195,9 +195,6 @@ if has apt; then
 elif has dnf; then
     # fedora
     _dnf "$@"
-elif has nix; then
-    # nix
-    _nix "$@"
 elif has pacman-key; then
     # arch/manjaro
     _pacman "$@"
@@ -207,6 +204,9 @@ elif has port; then
 elif has xbps-install; then
     # void
     _xbps "$@"
+elif has nix; then
+    # nix
+    _nix "$@"
 elif has brew; then
     pem "Homebrew is not supported [wontfix]"
     exit 1


### PR DESCRIPTION
If I'm on a distro like arch, I'd prefer installing through pacman instead of nix.