### PR TITLE
add Alpine package manager (apk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ sudo install -m755 cpm /bin/cpm
 
 ## Supported package managers
 
+- apk (Alpine)
 - apt (Debian/Ubuntu)
 - dnf (Fedora)
 - MacPorts (MacOS)

--- a/cpm
+++ b/cpm
@@ -126,7 +126,7 @@ _apk() {
 	upgrade) $SUDO apk upgrade;;
 	search)  $SUDO apk search -v "$1";;
 	show)    $SUDO apk search "$1";;
-	clean)   $SUDO echo "apk does not have an autoremove option!";;
+	clean)   $SUDO apk cache clean;;
     esac
 }
 

--- a/cpm
+++ b/cpm
@@ -116,6 +116,20 @@ elif [ "$(whoami)" != root ]; then
     SUDO='su root -c '\''"$@"'\'' -- -'
 fi
 
+_apk() {
+    case "$OP" in
+	install) $SUDO apk add "$@";;
+	remove)  $SUDO apk del "$@";;
+	list)    $SUDO apk info -vv;;
+	count)   $SUDO apk info --vv || tot;;
+	update)  $SUDO apk update;;
+	upgrade) $SUDO apk upgrade;;
+	search)  $SUDO apk search -v "$1";;
+	show)    $SUDO apk search "$1";;
+	clean)   $SUDO echo "apk does not have an autoremove option!";;
+    esac
+}
+
 _apt() {
     case "$OP" in
         install) $SUDO apt install "$@";;
@@ -200,7 +214,10 @@ _xbps() {
     esac
 }
 
-if has apt; then
+if   has apk; then
+    # alpine/adelie
+    _apk "$@"
+elif has apt; then
     # debian/ubuntu
     _apt "$@"
 elif has dnf; then


### PR DESCRIPTION
Adding support for apk, a package manager used by [Alpine](https://alpinelinux.org).

## PROBLEMS:

- `clean` does not work as apk doesn't have an equivalent.

## NOTES

- Apologies for not also editing the README


If there are any other problems, please notify me of them!