### PR TITLE
Don't restrict search/show to one argument

### DIFF
--- a/cpm
+++ b/cpm
@@ -58,18 +58,12 @@ case "$1" in
         if [ $# -lt 2 ]; then
             pem "$OP: please specify a package"
             exit 1
-        elif [ $# -gt 2 ]; then
-            pem "$OP: only one package may be queried at a time"
-            exit 1
         fi
         ;;
     S|show|I|info)
         OP='show'
         if [ $# -lt 2 ]; then
             pem "$OP: please specify a package"
-            exit 1
-        elif [ $# -gt 2 ]; then
-            pem "$OP: only one argument is allowed"
             exit 1
         fi
         ;;
@@ -150,8 +144,8 @@ _apk() {
         count)   apk -vv info | tot;;
         update)  $SUDO apk update;;
         upgrade) $SUDO apk upgrade;;
-        search)  apk search -v "$1";;
-        show)    apk search "$1";;
+        search)  apk search -v "$@";;
+        show)    apk search "$@";;
         from)    apk info --who-owns "$@";;
         files)   apk info -L "$@";;
         clean)   $SUDO apk cache clean;;
@@ -166,8 +160,8 @@ _apt() {
         count)   dpkg-query -f '.\n' -W | tot;;
         update)  $SUDO apt update;;
         upgrade) $SUDO apt dist-upgrade;;
-        search)  apt search "$1";;
-        show)    apt show "$1";;
+        search)  apt search "$@";;
+        show)    apt show "$@";;
         files)   dpkg -L "$@";;
         from)    dpkg -S "$@";;
         clean)   $SUDO apt autoremove;;
@@ -212,8 +206,8 @@ _dnf() {
         count)   rpm -qa | tot;;
         update)  $SUDO dnf check-update;;
         upgrade) $SUDO dnf distro-sync;;
-        search)  dnf search "$1";;
-        show)    dnf info "$1";;
+        search)  dnf search "$@";;
+        show)    dnf info "$@";;
         files)   dnf repoquery -l "$@";;
         from)    dnf provides "$@";;
         clean)   $SUDO dnf autoremove;;
@@ -228,8 +222,8 @@ _pacman() {
         count)   pacman -Q | tot;;
         update)  $SUDO pacman -Sy;;
         upgrade) $SUDO pacman -Syu;;
-        search)  pacman -Ss "$1";;
-        show)    pacman -Si "$1";;
+        search)  pacman -Ss "$@";;
+        show)    pacman -Si "$@";;
         files)   pacman -Ql "$@";;
         from)    pacman -Qo "$@";;
         clean)   $SUDO pacman -Rns $(pacman -Qtdq) && $SUDO pacman -Sc;;
@@ -244,8 +238,8 @@ _urpmi() {
         count)   rpm -qa | tot;;
         update)  $SUDO urpmi.update -a;;
         upgrade) $SUDO urpmi --auto-update;;
-        search)  urpmq -Y "$1";;
-        show)    urpmq --summary "$1";;
+        search)  urpmq -Y "$@";;
+        show)    urpmq --summary "$@";;
         files)   rpm -ql "$@";;
         from)    rpm -qf "$@";;
         clean)   $SUDO urpme --auto-orphans;;
@@ -260,8 +254,8 @@ _macports() {
         count)   port installed | tot;;
         update)  $SUDO port sync;;
         upgrade) $SUDO port selfupdate;;
-        search)  port search "$1";;
-        show)    port info "$1";;
+        search)  port search "$@";;
+        show)    port info "$@";;
         files)   port contents "$@";;
         from)    port provides "$@";;
         clean)   $SUDO port reclaim;;
@@ -276,8 +270,8 @@ _xbps() {
         count)   xbps-query -l | tot;;
         update)  $SUDO xbps-install -S;;
         upgrade) $SUDO xbps-install -Su xbps && $SUDO xbps-install -u;;
-        search)  xbps-query -s "$1" --repository;;
-        show)    xbps-query -S "$1" --repository;;
+        search)  xbps-query -s "$@" --repository;;
+        show)    xbps-query -S "$@" --repository;;
         files)   xbps-query -f "$1" --repository;;
         from)    xbps-query -o "$1" --repository;;
         clean)   $SUDO xbps-remove -ROo;;
@@ -292,8 +286,8 @@ _slackpkg() {
         count)   fcount /var/log/packages/*;;
         update)  $SUDO slackpkg update gpg && slackpkg update;;
         upgrade) $SUDO slackpkg upgrade-all;;
-        search)  slackpkg search "$1";;
-        show)    slackpkg info "$1";;
+        search)  slackpkg search "$@";;
+        show)    slackpkg info "$@";;
         from)    slackpkg file-search "$@";;
         files)   pem "unsupported because PM does not support it natively: see CONTRUBITING.md.";;
         clean)   $SUDO slackpkg clean-system;;


### PR DESCRIPTION
Multiple PMs support giving >1 packages, and having the restriction
also stops you from giving additional arguments to the PM

And if the PM does only support one argument, there is most likely a built-in error message.