### PR TITLE
from: fallback to command for non-existent files

### DIFF
--- a/cpm
+++ b/cpm
@@ -94,6 +94,7 @@ case "$1" in
     ;;
   f|from)
     OP='from'
+    [ -e "$2" ] || set -- from "$(command -v "$2")"
     ;;
   c|clean)
     OP='clean'


### PR DESCRIPTION
example (From a dir without that filename): `cpm f test` will be replaced with `cpm f /bin/test`, which will probably be coreutils.