### PR TITLE
deprecate update, fix upgrade and clean

### DIFF
--- a/cpm
+++ b/cpm
@@ -248,13 +248,15 @@ _dnf() {
     remove)  $SUDO dnf remove "$@";;
     list)    dnf list --installed;;
     count)   rpm -qa | tot;;
-    update)  $SUDO dnf check-update;;
-    upgrade) $SUDO dnf check-update && $SUDO dnf distro-sync;;
+    update)  echo "No DNF equivalent or smth tell me what to place here";;
+    upgrade) $SUDO dnf upgrade;;
     search)  dnf search "$@";;
     show)    dnf info "$@";;
     files)   dnf repoquery -l "$@";;
     from)    dnf provides "$@";;
-    clean)   $SUDO dnf autoremove;;
+    clean)   $SUDO dnf autoremove && $SUDO dnf clean all;;
+    # removes everything dnf cached along orphans
+  
   esac
 }
 

--- a/cpm
+++ b/cpm
@@ -255,8 +255,6 @@ _dnf() {
     files)   dnf repoquery -l "$@";;
     from)    dnf provides "$@";;
     clean)   $SUDO dnf autoremove && $SUDO dnf clean all;;
-    # removes everything dnf cached along orphans
-  
   esac
 }
 

--- a/cpm
+++ b/cpm
@@ -248,7 +248,7 @@ _dnf() {
     remove)  $SUDO dnf remove "$@";;
     list)    dnf list --installed;;
     count)   rpm -qa | tot;;
-    update)  echo "No DNF equivalent or smth tell me what to place here";;
+    update)  echo "DNF does not support this option.";;
     upgrade) $SUDO dnf upgrade;;
     search)  dnf search "$@";;
     show)    dnf info "$@";;


### PR DESCRIPTION
I still need a good message when someone tries to use `update`

`clean` will remove everything dnf has cached alongside orphaned packages
`upgrade` now uses `dnf upgrade`, `distro-sync` might be useful in the future when dealing with copr packages or from an rpm file