### PR TITLE
Add OpenBSD pkg_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ cpm [i|r|l|u|U|s|S|I|F|f|c|h] [pkg]...
 - urpmi (Mageia)
 - xbps (Void)
 - zypper (OpenSUSE)
+- pkg (OpenBSD)
 
 ## Explicitly unsupported package managers
 

--- a/cpm
+++ b/cpm
@@ -422,6 +422,22 @@ _guix() {
   esac
 }
 
+_pkg_() {
+  case "$OP" in
+    install) $SUDO pkg_add "$@";;
+    remove) $SUDO pkg_delete "$@";;
+    list) pkg_info -v;;
+    count) pkg_info -v | tot;;
+    update) pem "unsupported: repo list only changes when user performs sys upgrade";;
+    upgrade) $SUDO pkg_add -u;;
+    search) pkg_info "$@";;
+    show) pkg_info "$@";;
+    files) pkg_info -L "$@";;
+    from) pkg_info -qE "$@";;
+    clean) pem "unsupported: PM already does this";;
+  esac
+}
+
 # Use pm=PKG_MANAGER cpm COMMAND to force a specific cpm function
 # ie.: pm=portage cpm list
 if [ "$pm" ] && has "_$pm"; then
@@ -466,6 +482,9 @@ elif ! [ "$(uname -s)" = "Darwin" ]; then
   elif has guix; then
     # local (non-system-wide) guix
     _guix "$@"
+  elif has pkg_info; then
+    # openbsd
+    _pkg_ "$@"
   elif has snap; then
     pem "Snapd is not supported [wontfix]"
     exit 1


### PR DESCRIPTION
Note on the name: using just `pkg` would be ambiguous, as FreeBSD has its own package manager called `pkg` that implements all of its functions into one program, meanwhile OpenBSD uses various different programs to perform tasks (e.g. `pkg_info`, `pkg_add`, etc).